### PR TITLE
Added TLS support for Nats webhook provider

### DIFF
--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -99,11 +99,15 @@ type Endpoint struct {
 		CreateQueue bool
 	}
 	NATS struct {
-		Host  string
-		Port  int
-		User  string
-		Pass  string
-		Topic string
+		Host    string
+		Port    int
+		User    string
+		Pass    string
+		Topic   string
+		Token   string
+		TLS     bool
+		TLSCert string
+		TLSKey  string
 	}
 	Local struct {
 		Channel string
@@ -656,6 +660,14 @@ func parseEndpoint(s string) (Endpoint, error) {
 					endpoint.NATS.User = val[0]
 				case "pass":
 					endpoint.NATS.Pass = val[0]
+				case "token":
+					endpoint.NATS.Token = val[0]
+				case "tls":
+					endpoint.NATS.TLS = queryBool(val[0])
+				case "tlscert":
+					endpoint.NATS.TLSCert = val[0]
+				case "tlskey":
+					endpoint.NATS.TLSKey = val[0]
 				}
 			}
 		}

--- a/internal/endpoint/nats.go
+++ b/internal/endpoint/nats.go
@@ -59,13 +59,21 @@ func (conn *NATSConn) Send(msg string) error {
 	}
 	conn.t = time.Now()
 	if conn.conn == nil {
-		addr := fmt.Sprintf("nats://%s:%d", conn.ep.NATS.Host, conn.ep.NATS.Port)
+		addr := fmt.Sprintf("%s:%d", conn.ep.NATS.Host, conn.ep.NATS.Port)
 		var err error
+		var opts []nats.Option
 		if conn.ep.NATS.User != "" && conn.ep.NATS.Pass != "" {
-			conn.conn, err = nats.Connect(addr, nats.UserInfo(conn.ep.NATS.User, conn.ep.NATS.Pass))
-		} else {
-			conn.conn, err = nats.Connect(addr)
+			opts = append(opts, nats.UserInfo(conn.ep.NATS.User, conn.ep.NATS.Pass))
 		}
+		if conn.ep.NATS.TLS {
+			opts = append(opts, nats.ClientCert(
+				conn.ep.NATS.TLSCert, conn.ep.NATS.TLSKey,
+			))
+		}
+		if conn.ep.NATS.Token != "" {
+			opts = append(opts, nats.Token(conn.ep.NATS.Token))
+		}
+		conn.conn, err = nats.Connect(addr, opts...)
 		if err != nil {
 			conn.close()
 			return err


### PR DESCRIPTION
Use the `tls=1` and the set the the `tlscert` and `tlskey` query
string params. The cert and key files must be on the tile38
server and the Nats server must be started using the same files.

nats://54.12.34.121:4222/fleet?tls=1&tlscert=cert.crt&tlskey=cert.key